### PR TITLE
Support proxy servers

### DIFF
--- a/lib/squash/ruby.rb
+++ b/lib/squash/ruby.rb
@@ -215,6 +215,9 @@ module Squash
     # contain the given headers and body. It should not eat any exceptions
     # relating to HTTP connectivity issues.
     #
+    # It supports the linux idiom of setting environment variables `http_proxy`
+    # and `https_proxy` to configure a proxy server for the connection.
+    #
     # Your implementation should also respect the value of the
     # `transmit_timeout` configuration, which is accessible using
     # `configuration(:transmit_timeout)`.
@@ -227,7 +230,18 @@ module Squash
 
     def self.http_transmit(url, headers, body)
       uri  = URI.parse(url)
-      http = Net::HTTP.new(uri.host, uri.port)
+
+      http = if ENV['http_proxy']
+        proxy = if uri.scheme == "https" && ENV['https_proxy']
+          URI.parse("https://#{ENV['https_proxy']}")
+        else
+          URI.parse("http://#{ENV['http_proxy']}")
+        end
+        Net::HTTP::Proxy(proxy.host, proxy.port, proxy.user, proxy.password).new(uri.host, uri.port)
+      else
+        Net::HTTP.new(uri.host, uri.port)
+      end
+
       http_options(uri).each { |k, v| http.send :"#{k}=", v }
 
       block = lambda do


### PR DESCRIPTION
Many of the Linux utilities support environment variable `http_proxy` to connect via a proxy server. This idiom is also supported by Capistrano with configuration settings `default_environment['http_proxy']` and `default_environment['https_proxy']`. With these settings enabled deployment environment contains variables `http_proxy` and `https_proxy` which this pull request takes advantage of.

Perhaps it would be elegant to be able to provide proxy settings for `Squash::Ruby.configure`, but I wanted to keep this proposition as simple as possible.
