### PR TITLE
add squash_ruby.rb under lib so no custom require is required

### DIFF
--- a/lib/squash_ruby.rb
+++ b/lib/squash_ruby.rb
@@ -1,0 +1,1 @@
+require 'squash/ruby'


### PR DESCRIPTION
Any thoughts about making the gem so a custom require in the Gemfile is not required?
