### PR TITLE
option to exclude env_vars

### DIFF
--- a/lib/squash/ruby.rb
+++ b/lib/squash/ruby.rb
@@ -44,6 +44,7 @@ module Squash
         timeout_protection:         proc { |timeout, &block|
                                          timeout_protection(timeout, &block)
                                        },
+        include_env:                true,
     }
     # Types that are serialized directly to JSON, rather than to a hash of
     # object information. Subclasses are not considered members of this array.
@@ -423,7 +424,12 @@ module Squash
     end
 
     def self.configuration(key)
-      (@configuration || CONFIGURATION_DEFAULTS)[key] || CONFIGURATION_DEFAULTS[key]
+      cfg = (@configuration || CONFIGURATION_DEFAULTS)
+      if cfg.key?(key)
+        cfg[key]
+      else
+        CONFIGURATION_DEFAULTS[key]
+      end
     end
 
     def self.ignored?(exception, user_data)
@@ -652,12 +658,15 @@ module Squash
 
     # @private
     def self.environment_data
-      {
+      data = {
           'pid'       => Process.pid,
           'hostname'  => Socket.gethostname,
-          'env_vars'  => ENV.inject({}) { |hsh, (k, v)| hsh[k.to_s] = valueify(v); hsh },
           'arguments' => ARGV.join(' ')
       }
+      if configuration(:include_env)
+        data['env_vars'] = ENV.inject({}) { |hsh, (k, v)| hsh[k.to_s] = valueify(v); hsh }
+      end
+      data
     end
 
     # @private


### PR DESCRIPTION
We have a handful of sensitive environment variables in each of our apps
(12-factor apps) and we feel it'd be best to just exclude the
environment completely.

In theory this could be done by overriding value_filter with something like:

``` ruby
def self.value_filter(value)
  ENV.values.include?(value) ? nil : value
end
```

but this seems a lot more straightforward. Thanks!
