### PR TITLE
make sure original_exception exists

### DIFF
--- a/lib/squash/ruby.rb
+++ b/lib/squash/ruby.rb
@@ -727,7 +727,7 @@ module Squash
 
     # @private
     def self.unroll(exception)
-      if exception.respond_to?(:original_exception)
+      if exception.respond_to?(:original_exception) && exception.original_exception
         [exception.original_exception, [exception]]
       else
         [exception, nil]


### PR DESCRIPTION
Some invalid URL chars were throwing `ActionController::BadRequest` errors in a rails project.
The errors were getting swallowed by the failsafe and not reporting to squash because the exception responds to `original_exception` but returns `nil`